### PR TITLE
Adiciona site do evento PHP Velho Oeste

### DIFF
--- a/template/index.phtml
+++ b/template/index.phtml
@@ -106,6 +106,7 @@ $wordpressTotalUsagePercentage = number_format($wordpressTotalUsagePercentage, 1
                     <h3>Eventos nacionais</h3>
                     <ul>
                         <li><a href="https://php.darkmiratour.rocks/">Darkmira Tour</a></li>
+                        <li><a href="https://www.phpvelhoeste.com.br/">PHP Velho Oeste</a></li>
                         <li><a href="https://php.locaweb.com.br/">PHP Community Summit</a></li>
                         <li><a href="https://phpconference.com.br/">PHP Conference</a></li>
                         <li><a href="https://www.phpeste.org/">PHPeste</a></li>


### PR DESCRIPTION
O PHP Velho oeste é uma comunidade que realiza eventos todo ano de PHP, ví que não colocaram ainda no site, decidi adicionar, acho uma adição super importante, valeu.